### PR TITLE
Fix ContentTemplate for switch to inner ContentPresenter for swapping Skia Panels

### DIFF
--- a/labs/RivePlayer/src/RivePlayer.Platform.cs
+++ b/labs/RivePlayer/src/RivePlayer.Platform.cs
@@ -2,20 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace CommunityToolkit.Labs.WinUI.Rive;
-
-// This file contains platform-specific customizations of RivePlayer.
-
-#if WINDOWS_WINAPPSDK || HAS_UNO_WASM
-
 #if WINDOWS_WINAPPSDK
 using SkiaSharp.Views.Windows;
 #else
+// SkiaSharp.Views.UWP is on Uno too.
 using SkiaSharp.Views.UWP;
 #endif
 
-// WinAppSdk doesn't have SKSwapChainPanel yet.
-// SKSwapChainPanel doesn't work in WASM yet.
+namespace CommunityToolkit.Labs.WinUI.Rive;
+
+// This file contains platform-specific customizations of RivePlayer.
 public partial class RivePlayer
 {
     // SKXamlCanvas doesn't support rendering in a background thread.
@@ -26,9 +22,18 @@ public partial class RivePlayer
         _skiaSurface = GetTemplateChild(SkiaSurfacePartName) as ContentPresenter;
         if (_skiaSurface != null && _skiaSurface.Content == null)
         {
+#if WINDOWS_WINAPPSDK || HAS_UNO_WASM
+            // WinAppSdk doesn't have SKSwapChainPanel yet.
+            // SKSwapChainPanel doesn't work in WASM yet.
             var xamlCanvas = new SKXamlCanvas();
             xamlCanvas.PaintSurface += OnPaintSurface;
             _skiaSurface.Content = xamlCanvas;
+#else
+            // SKSwapChainPanel performs better than SKXamlCanvas.
+            var swapChainPanel = new SKSwapChainPanel();
+            swapChainPanel.PaintSurface += OnPaintSurface;
+            _skiaSurface.Content = swapChainPanel;
+#endif
             _invalidateTimer = new InvalidateTimer(this, fps: 120);
         }
         base.OnApplyTemplate();
@@ -36,41 +41,21 @@ public partial class RivePlayer
 
     internal void Invalidate()
     {
+#if WINDOWS_WINAPPSDK || HAS_UNO_WASM
         var xamlCanvas = _skiaSurface?.Content as SKXamlCanvas;
         xamlCanvas?.Invalidate();
+#else
+        var swapChainPanel = _skiaSurface?.Content as SKSwapChainPanel;
+        swapChainPanel?.Invalidate();
+#endif
     }
 
+#if WINDOWS_WINAPPSDK || HAS_UNO_WASM
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
         this.PaintNextAnimationFrame(e.Surface, e.Info.Width, e.Info.Height);
     }
 #else
-
-// SkiaSharp.Views.UWP is on Uno too.
-using SkiaSharp.Views.UWP;
-
-// SKSwapChainPanel performs better than SKXamlCanvas.
-public partial class RivePlayer
-{
-    public bool DrawInBackground { get; set; }
-
-    protected override void OnApplyTemplate()
-    {
-        _skiaSurface = GetTemplateChild(SkiaSurfacePartName) as ContentPresenter;
-        if (_skiaSurface != null && _skiaSurface.Content == null)
-        {
-            var swapChainPanel = new SKSwapChainPanel();
-            swapChainPanel.PaintSurface += OnPaintSurface;
-            _skiaSurface.Content = swapChainPanel;
-            _invalidateTimer = new InvalidateTimer(this, fps: 120);
-        }
-        base.OnApplyTemplate();
-    }
-
-    internal void Invalidate()
-    {
-    }
-
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs e)
     {
         this.PaintNextAnimationFrame(e.Surface, e.BackendRenderTarget.Width, e.BackendRenderTarget.Height);

--- a/labs/RivePlayer/src/RivePlayer.cs
+++ b/labs/RivePlayer/src/RivePlayer.cs
@@ -34,6 +34,8 @@ public sealed partial class RivePlayer : Control
 
     public RivePlayer()
     {
+        this.DefaultStyleKey = typeof(RivePlayer);
+
         this.StateMachineInputCollection.SetRivePlayer(this);
         this.Loaded += OnLoaded;
         this.PointerPressed +=

--- a/labs/RivePlayer/src/RivePlayer.xaml
+++ b/labs/RivePlayer/src/RivePlayer.xaml
@@ -9,7 +9,18 @@
     <Style TargetType="Rive:RivePlayer">
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="x:ContentPresenter" />
+                <ControlTemplate TargetType="Rive:RivePlayer">
+                    <ContentPresenter x:Name="SkiaSurface"
+                                      Background="{TemplateBinding Background}"
+                                      BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      CornerRadius="{TemplateBinding CornerRadius}"
+                                      Padding="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="Stretch"
+                                      VerticalContentAlignment="Stretch"
+                                      AutomationProperties.AccessibilityView="Raw"/>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>


### PR DESCRIPTION
Was missing `DefaultStyleKey` and had invalid `ContentTemplate`.

Now `OnApplyTemplate` is properly called and control is initialized.

Also cleaned-up the `#if` to inline the code and make it easier to see where the specific platform differences are. Should make it more maintainable moving forward. I also think Invalidate wasn't being called for the swapchain version, so this highlighted that gap as well.

Getting an error trying to test on WASM though about `rive.dll`; otherwise, this code seems to work fine on UWP and Windows App SDK sample heads.